### PR TITLE
Optimize keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [
     "magicmirror",
-    "publictransport"
+    "public transport"
   ],
   "author": "anders@boghammar.com",
   "license": "MIT",


### PR DESCRIPTION
We are using the keywords in [the new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/). There is "Public Transport" used instead of "PublicTransport".

Thanks for the module! :smiley: